### PR TITLE
Update metals to 0.11.12+74-b0b0178d-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "0.11.12+73-f470c9c8-SNAPSHOT";
-  "outputHash" = "sha256-KFd1uQFaQ4QokCT2cD6j0tU+T7XJ+hEIZ/u06wm60gE=";
+  "version" = "0.11.12+74-b0b0178d-SNAPSHOT";
+  "outputHash" = "sha256-i9rqSAYeMEfz1bD0IaAkLdkOCAcQz59sThFY1tPIvPA=";
 }


### PR DESCRIPTION
Update metals to version `0.11.12+74-b0b0178d-SNAPSHOT`. See https://scalameta.org/metals/latests.json