### PR TITLE
Update metals to 0.11.12+77-cce28f19-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "0.11.12+74-b0b0178d-SNAPSHOT";
-  "outputHash" = "sha256-i9rqSAYeMEfz1bD0IaAkLdkOCAcQz59sThFY1tPIvPA=";
+  "version" = "0.11.12+77-cce28f19-SNAPSHOT";
+  "outputHash" = "sha256-oOnjo5C/Tc4Rnmece2dbKA+V+rjwuo7joSB+l5zrfyI=";
 }


### PR DESCRIPTION
Update metals to version `0.11.12+77-cce28f19-SNAPSHOT`. See https://scalameta.org/metals/latests.json