### PR TITLE
Update metals to 0.11.12+97-f10f3269-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "0.11.12+91-8ed12f69-SNAPSHOT";
-  "outputHash" = "sha256-w19yZILD0xPvJ6BdLdq2KTine13NHG+bCkeH2DKvCn4=";
+  "version" = "0.11.12+97-f10f3269-SNAPSHOT";
+  "outputHash" = "sha256-XVgICxbeiJH+yCg6bwSYv/2mx2jfMgvu03x5OPbQtBY=";
 }


### PR DESCRIPTION
Update metals to version `0.11.12+97-f10f3269-SNAPSHOT`. See https://scalameta.org/metals/latests.json