### PR TITLE
Update metals to 0.11.12+105-8283260d-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "0.11.12+97-f10f3269-SNAPSHOT";
-  "outputHash" = "sha256-XVgICxbeiJH+yCg6bwSYv/2mx2jfMgvu03x5OPbQtBY=";
+  "version" = "0.11.12+105-8283260d-SNAPSHOT";
+  "outputHash" = "sha256-TJKC1X+6/1aPhnfB5VuPMjGsmoTDEft9cv3y6++4kHA=";
 }


### PR DESCRIPTION
Update metals to version `0.11.12+105-8283260d-SNAPSHOT`. See https://scalameta.org/metals/latests.json