### PR TITLE
Update metals to 0.11.12+123-68e76634-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "0.11.12+105-8283260d-SNAPSHOT";
-  "outputHash" = "sha256-TJKC1X+6/1aPhnfB5VuPMjGsmoTDEft9cv3y6++4kHA=";
+  "version" = "0.11.12+123-68e76634-SNAPSHOT";
+  "outputHash" = "sha256-ltAWgmetz0Y29jc1ZQcaXW/PtWHEYNIj55ZSLxb85JQ=";
 }


### PR DESCRIPTION
Update metals to version `0.11.12+123-68e76634-SNAPSHOT`. See https://scalameta.org/metals/latests.json