### PR TITLE
Update metals to 0.11.12+139-bc1e7dad-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "0.11.12+123-68e76634-SNAPSHOT";
-  "outputHash" = "sha256-ltAWgmetz0Y29jc1ZQcaXW/PtWHEYNIj55ZSLxb85JQ=";
+  "version" = "0.11.12+139-bc1e7dad-SNAPSHOT";
+  "outputHash" = "sha256-pyzltlfQjvqbUl/fryM/fXWwD0RUg0ljSaqvw/QVLCA=";
 }


### PR DESCRIPTION
Update metals to version `0.11.12+139-bc1e7dad-SNAPSHOT`. See https://scalameta.org/metals/latests.json