### PR TITLE
Update metals to 0.11.12+160-84f04454-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "0.11.12+139-bc1e7dad-SNAPSHOT";
-  "outputHash" = "sha256-pyzltlfQjvqbUl/fryM/fXWwD0RUg0ljSaqvw/QVLCA=";
+  "version" = "0.11.12+160-84f04454-SNAPSHOT";
+  "outputHash" = "sha256-FoQNht+hl+uBCBAqAwh/XGOzPSlalk7qd1RFdj0NDbQ=";
 }


### PR DESCRIPTION
Update metals to version `0.11.12+160-84f04454-SNAPSHOT`. See https://scalameta.org/metals/latests.json