### PR TITLE
Update metals to 1.0.0

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "0.11.12";
-  "outputHash" = "sha256-3zYjjrd3Hc2T4vwnajiAMNfTDUprKJZnZp2waRLQjI4=";
+  "version" = "1.0.0";
+  "outputHash" = "sha256-futBxdMEJN0UdDvlk5FLUUmcG7r7P7D81IhbC2oYn5s=";
 }


### PR DESCRIPTION
Update metals to version `1.0.0`. See https://scalameta.org/metals/latests.json