### PR TITLE
Update metals to 1.0.0+58-ccd5153a-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.0.0+35-f2760702-SNAPSHOT";
-  "outputHash" = "sha256-UuxMTJjrXiQmI3LYppwKVrzmb6NiJjb13uqPmbaMV3E=";
+  "version" = "1.0.0+58-ccd5153a-SNAPSHOT";
+  "outputHash" = "sha256-VMw9zxvRWBHDpLSjA334oL4NDJaWCMEC6aFCiKLdBPQ=";
 }


### PR DESCRIPTION
Update metals to version `1.0.0+58-ccd5153a-SNAPSHOT`. See https://scalameta.org/metals/latests.json