### PR TITLE
Update metals to 1.0.0+67-f04fcefb-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.0.0+58-ccd5153a-SNAPSHOT";
-  "outputHash" = "sha256-VMw9zxvRWBHDpLSjA334oL4NDJaWCMEC6aFCiKLdBPQ=";
+  "version" = "1.0.0+67-f04fcefb-SNAPSHOT";
+  "outputHash" = "sha256-17OPWQat3ez7ZAnNI2pkpWO3KXrY0ehYL4i7+9+I2t8=";
 }


### PR DESCRIPTION
Update metals to version `1.0.0+67-f04fcefb-SNAPSHOT`. See https://scalameta.org/metals/latests.json