### PR TITLE
Update metals to 1.0.0+71-dae65412-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.0.0+67-f04fcefb-SNAPSHOT";
-  "outputHash" = "sha256-17OPWQat3ez7ZAnNI2pkpWO3KXrY0ehYL4i7+9+I2t8=";
+  "version" = "1.0.0+71-dae65412-SNAPSHOT";
+  "outputHash" = "sha256-qnDl8CPkO4mA04ZAkSE+TlfuuiEJxssbev5kNTxpScA=";
 }


### PR DESCRIPTION
Update metals to version `1.0.0+71-dae65412-SNAPSHOT`. See https://scalameta.org/metals/latests.json