### PR TITLE
Update metals to 1.0.0+84-80283cf8-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.0.0+71-dae65412-SNAPSHOT";
-  "outputHash" = "sha256-qnDl8CPkO4mA04ZAkSE+TlfuuiEJxssbev5kNTxpScA=";
+  "version" = "1.0.0+84-80283cf8-SNAPSHOT";
+  "outputHash" = "sha256-3gfC8nIhcIOAK5yfme0NgvITJLMg5zj66rjGswq6emI=";
 }


### PR DESCRIPTION
Update metals to version `1.0.0+84-80283cf8-SNAPSHOT`. See https://scalameta.org/metals/latests.json