### PR TITLE
Update metals to 1.0.1

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.0.0";
-  "outputHash" = "sha256-futBxdMEJN0UdDvlk5FLUUmcG7r7P7D81IhbC2oYn5s=";
+  "version" = "1.0.1";
+  "outputHash" = "sha256-AamUE6mr9fwjbDndQtzO2Yscu2T6zUW/DiXMYwv35YE=";
 }


### PR DESCRIPTION
Update metals to version `1.0.1`. See https://scalameta.org/metals/latests.json