### PR TITLE
Update metals to 1.0.1+16-5b3005b2-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.0.0+84-80283cf8-SNAPSHOT";
-  "outputHash" = "sha256-3gfC8nIhcIOAK5yfme0NgvITJLMg5zj66rjGswq6emI=";
+  "version" = "1.0.1+16-5b3005b2-SNAPSHOT";
+  "outputHash" = "sha256-f0Wj2DRxOcAWeCXnvPnolqbDKwDqRVzpa0bYHPmsAcE=";
 }


### PR DESCRIPTION
Update metals to version `1.0.1+16-5b3005b2-SNAPSHOT`. See https://scalameta.org/metals/latests.json