### PR TITLE
Update metals to 1.0.1+32-8d80aacd-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.0.1+27-38181619-SNAPSHOT";
-  "outputHash" = "sha256-7oye4z3hOkw6J78SkDh871IC+6oAqy3YQEnCTzuA+tM=";
+  "version" = "1.0.1+32-8d80aacd-SNAPSHOT";
+  "outputHash" = "sha256-1P+Yd6btdKLD+Fhz0+0fYw9UOZcY8JrN0M8grvCw7jo=";
 }


### PR DESCRIPTION
Update metals to version `1.0.1+32-8d80aacd-SNAPSHOT`. See https://scalameta.org/metals/latests.json