### PR TITLE
Update metals to 1.0.1+49-8f6d1582-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.0.1+32-8d80aacd-SNAPSHOT";
-  "outputHash" = "sha256-1P+Yd6btdKLD+Fhz0+0fYw9UOZcY8JrN0M8grvCw7jo=";
+  "version" = "1.0.1+49-8f6d1582-SNAPSHOT";
+  "outputHash" = "sha256-Jf36gSivlsjPwFZMJvCKb4AypdEDVU1rFmszXtcLPnY=";
 }


### PR DESCRIPTION
Update metals to version `1.0.1+49-8f6d1582-SNAPSHOT`. See https://scalameta.org/metals/latests.json