### PR TITLE
Update metals to 1.0.1+60-26f1e686-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.0.1+49-8f6d1582-SNAPSHOT";
-  "outputHash" = "sha256-Jf36gSivlsjPwFZMJvCKb4AypdEDVU1rFmszXtcLPnY=";
+  "version" = "1.0.1+60-26f1e686-SNAPSHOT";
+  "outputHash" = "sha256-dGqVlBxN5TpcOz0uxuRzEIq41hu3vdfTrIWQ+/54hKI=";
 }


### PR DESCRIPTION
Update metals to version `1.0.1+60-26f1e686-SNAPSHOT`. See https://scalameta.org/metals/latests.json