### PR TITLE
Update metals to 1.0.1+89-4bb3aeb3-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.0.1+60-26f1e686-SNAPSHOT";
-  "outputHash" = "sha256-dGqVlBxN5TpcOz0uxuRzEIq41hu3vdfTrIWQ+/54hKI=";
+  "version" = "1.0.1+89-4bb3aeb3-SNAPSHOT";
+  "outputHash" = "sha256-M1ZP/F9+BtTAxdl9sdMfm92eocNEw8FT7PJNwcEZYK0=";
 }


### PR DESCRIPTION
Update metals to version `1.0.1+89-4bb3aeb3-SNAPSHOT`. See https://scalameta.org/metals/latests.json