### PR TITLE
Update metals to 1.0.1+109-63a65d29-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.0.1+89-4bb3aeb3-SNAPSHOT";
-  "outputHash" = "sha256-M1ZP/F9+BtTAxdl9sdMfm92eocNEw8FT7PJNwcEZYK0=";
+  "version" = "1.0.1+109-63a65d29-SNAPSHOT";
+  "outputHash" = "sha256-MTvo6aWjGD2hwicomrqaU3SCAl+eucbR/9VKZw1cUCc=";
 }


### PR DESCRIPTION
Update metals to version `1.0.1+109-63a65d29-SNAPSHOT`. See https://scalameta.org/metals/latests.json