### PR TITLE
Update metals to 1.1.0

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.0.1";
-  "outputHash" = "sha256-AamUE6mr9fwjbDndQtzO2Yscu2T6zUW/DiXMYwv35YE=";
+  "version" = "1.1.0";
+  "outputHash" = "sha256-9zigJM0xEJSYgohbjc9ZLBKbPa/WGVSv3KVFE3QUzWE=";
 }


### PR DESCRIPTION
Update metals to version `1.1.0`. See https://scalameta.org/metals/latests.json