### PR TITLE
Update metals to 1.1.0+39-f985a070-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.1.0+12-fb4b2515-SNAPSHOT";
-  "outputHash" = "sha256-vkdl4OjlTZKXg65QlM//GafPLgcGbUd4xYwj1fysVMw=";
+  "version" = "1.1.0+39-f985a070-SNAPSHOT";
+  "outputHash" = "sha256-Zzpd9Tdd4ntfgCAppklAycnjQ9rbbGRjm5iulL5VYk8=";
 }


### PR DESCRIPTION
Update metals to version `1.1.0+39-f985a070-SNAPSHOT`. See https://scalameta.org/metals/latests.json