### PR TITLE
Update metals to 1.1.0+65-9a1575b9-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.1.0+53-af181de4-SNAPSHOT";
-  "outputHash" = "sha256-Wvy4eoJ1MNWTNJN6vK3LIPrEcOhcyvY068ZjkE4s6Uw=";
+  "version" = "1.1.0+65-9a1575b9-SNAPSHOT";
+  "outputHash" = "sha256-kSAlDq/Dpb3nUBLmdSi37VnkuQafcJuH36Sf3Dcp9Bw=";
 }


### PR DESCRIPTION
Update metals to version `1.1.0+65-9a1575b9-SNAPSHOT`. See https://scalameta.org/metals/latests.json