### PR TITLE
Update metals to 1.1.0+92-a07ab91c-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.1.0+65-9a1575b9-SNAPSHOT";
-  "outputHash" = "sha256-kSAlDq/Dpb3nUBLmdSi37VnkuQafcJuH36Sf3Dcp9Bw=";
+  "version" = "1.1.0+92-a07ab91c-SNAPSHOT";
+  "outputHash" = "sha256-MSfGUT+LmGhN5lwHAjbjgT0yGkFS18hj1vHYVgcfIFc=";
 }


### PR DESCRIPTION
Update metals to version `1.1.0+92-a07ab91c-SNAPSHOT`. See https://scalameta.org/metals/latests.json