### PR TITLE
Update metals to 1.1.0+108-ea38fec3-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.1.0+92-a07ab91c-SNAPSHOT";
-  "outputHash" = "sha256-MSfGUT+LmGhN5lwHAjbjgT0yGkFS18hj1vHYVgcfIFc=";
+  "version" = "1.1.0+108-ea38fec3-SNAPSHOT";
+  "outputHash" = "sha256-SRetKlSkoNSkECCxxnO0ersKOqQRii3gkOunmnRoCzQ=";
 }


### PR DESCRIPTION
Update metals to version `1.1.0+108-ea38fec3-SNAPSHOT`. See https://scalameta.org/metals/latests.json