### PR TITLE
Update metals to 1.1.0+124-1870e898-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.1.0+108-ea38fec3-SNAPSHOT";
-  "outputHash" = "sha256-SRetKlSkoNSkECCxxnO0ersKOqQRii3gkOunmnRoCzQ=";
+  "version" = "1.1.0+124-1870e898-SNAPSHOT";
+  "outputHash" = "sha256-eDH5iJgLPIKr1rO5PrjFKvP/PCiMn3aSVYjVk8PNqwo=";
 }


### PR DESCRIPTION
Update metals to version `1.1.0+124-1870e898-SNAPSHOT`. See https://scalameta.org/metals/latests.json