### PR TITLE
Update metals to 1.1.0+146-2014643e-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.1.0+124-1870e898-SNAPSHOT";
-  "outputHash" = "sha256-eDH5iJgLPIKr1rO5PrjFKvP/PCiMn3aSVYjVk8PNqwo=";
+  "version" = "1.1.0+146-2014643e-SNAPSHOT";
+  "outputHash" = "sha256-2Orj03N04FIVLub3koM8Qos5XfFk4LVA6eeqWjNIo7w=";
 }


### PR DESCRIPTION
Update metals to version `1.1.0+146-2014643e-SNAPSHOT`. See https://scalameta.org/metals/latests.json