### PR TITLE
Update metals to 1.2.0+13-615add64-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.1.0";
-  "outputHash" = "sha256-9zigJM0xEJSYgohbjc9ZLBKbPa/WGVSv3KVFE3QUzWE=";
+  "version" = "1.2.0+13-615add64-SNAPSHOT";
+  "outputHash" = "sha256-9ctRngrQfRQgfHTfxkT70pLm5FYs719rs2/wGjt2Io8=";
 }


### PR DESCRIPTION
Update metals to version `1.2.0+13-615add64-SNAPSHOT`. See https://scalameta.org/metals/latests.json