### PR TITLE
Update metals to 1.2.0

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.1.0";
-  "outputHash" = "sha256-9zigJM0xEJSYgohbjc9ZLBKbPa/WGVSv3KVFE3QUzWE=";
+  "version" = "1.2.0";
+  "outputHash" = "sha256-nikQ/GFRWmYYzboc9TWIi9gd5kwgCxOLhvIEQWusFik=";
 }


### PR DESCRIPTION
Update metals to version `1.2.0`. See https://scalameta.org/metals/latests.json