### PR TITLE
Update metals to 1.2.0+48-5b51c221-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.2.0+34-276a02c5-SNAPSHOT";
-  "outputHash" = "sha256-0M8TSX9QjrQ95ioae+zbSGNvIS+iteAva2X4jwvwi+w=";
+  "version" = "1.2.0+48-5b51c221-SNAPSHOT";
+  "outputHash" = "sha256-Ys7rjWoNgFxiZO33TkwtrvdGNmzCy8pcrQgPHIm6j4Q=";
 }


### PR DESCRIPTION
Update metals to version `1.2.0+48-5b51c221-SNAPSHOT`. See https://scalameta.org/metals/latests.json