### PR TITLE
Update metals to 1.2.0+62-0ec94060-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.2.0+48-5b51c221-SNAPSHOT";
-  "outputHash" = "sha256-Ys7rjWoNgFxiZO33TkwtrvdGNmzCy8pcrQgPHIm6j4Q=";
+  "version" = "1.2.0+62-0ec94060-SNAPSHOT";
+  "outputHash" = "sha256-J2pvQ6dGjYlfiDmdPhAJ02Vy2MWxGxAaSgj9OH5bpmg=";
 }


### PR DESCRIPTION
Update metals to version `1.2.0+62-0ec94060-SNAPSHOT`. See https://scalameta.org/metals/latests.json