### PR TITLE
Update metals to 1.2.0+107-af9ea93e-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.2.0+87-6b8b0081-SNAPSHOT";
-  "outputHash" = "sha256-qn9h7OU8ec6R5BKKFgs5NA75EUjS9xmIiLjpxcwkSGY=";
+  "version" = "1.2.0+107-af9ea93e-SNAPSHOT";
+  "outputHash" = "sha256-4Rcu1BljiO1Tq+lzcfAs0U+TqMfI6YdWcrClSo9FGMs=";
 }


### PR DESCRIPTION
Update metals to version `1.2.0+107-af9ea93e-SNAPSHOT`. See https://scalameta.org/metals/latests.json