### PR TITLE
Update metals to 1.2.1

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.2.0";
-  "outputHash" = "sha256-nikQ/GFRWmYYzboc9TWIi9gd5kwgCxOLhvIEQWusFik=";
+  "version" = "1.2.1";
+  "outputHash" = "sha256-L/ltoLlr4TdsDYwYtaCs6+Q2yTiyzoa2GQ3VK28AlzE=";
 }


### PR DESCRIPTION
Update metals to version `1.2.1`. See https://scalameta.org/metals/latests.json