### PR TITLE
Update metals to 1.2.1+4-193d123b-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.2.0+107-af9ea93e-SNAPSHOT";
-  "outputHash" = "sha256-4Rcu1BljiO1Tq+lzcfAs0U+TqMfI6YdWcrClSo9FGMs=";
+  "version" = "1.2.1+4-193d123b-SNAPSHOT";
+  "outputHash" = "sha256-mtuzkRcSesc6FiIRZu8ojTTB2MSdpScS3YW0jb4RbBk=";
 }


### PR DESCRIPTION
Update metals to version `1.2.1+4-193d123b-SNAPSHOT`. See https://scalameta.org/metals/latests.json