### PR TITLE
Update metals to 1.2.2

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.2.1";
-  "outputHash" = "sha256-L/ltoLlr4TdsDYwYtaCs6+Q2yTiyzoa2GQ3VK28AlzE=";
+  "version" = "1.2.2";
+  "outputHash" = "sha256-xk2ionn/lBV8AR7n7OR03UuRCoP1/K6KuohhpRwFock=";
 }


### PR DESCRIPTION
Update metals to version `1.2.2`. See https://scalameta.org/metals/latests.json