### PR TITLE
Update metals to 1.2.1+17-a2940786-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.2.1+4-193d123b-SNAPSHOT";
-  "outputHash" = "sha256-mtuzkRcSesc6FiIRZu8ojTTB2MSdpScS3YW0jb4RbBk=";
+  "version" = "1.2.1+17-a2940786-SNAPSHOT";
+  "outputHash" = "sha256-mr/sU8t+InyVHt6XS8+U5rHY3WBF61jtZ1nrZ1mr+oM=";
 }


### PR DESCRIPTION
Update metals to version `1.2.1+17-a2940786-SNAPSHOT`. See https://scalameta.org/metals/latests.json