### PR TITLE
Update metals to 1.2.2+38-fdcfaaed-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.2.1+17-a2940786-SNAPSHOT";
-  "outputHash" = "sha256-mr/sU8t+InyVHt6XS8+U5rHY3WBF61jtZ1nrZ1mr+oM=";
+  "version" = "1.2.2+38-fdcfaaed-SNAPSHOT";
+  "outputHash" = "sha256-fVb9iEJzbSOaU9L+bg85fhFkoXJ0BxnTl2ORH1fLplo=";
 }


### PR DESCRIPTION
Update metals to version `1.2.2+38-fdcfaaed-SNAPSHOT`. See https://scalameta.org/metals/latests.json