### PR TITLE
Update metals to 1.2.2+57-f1608f84-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.2.2+38-fdcfaaed-SNAPSHOT";
-  "outputHash" = "sha256-fVb9iEJzbSOaU9L+bg85fhFkoXJ0BxnTl2ORH1fLplo=";
+  "version" = "1.2.2+57-f1608f84-SNAPSHOT";
+  "outputHash" = "sha256-b8YL263aBTJuxieiQfsRtlr38+T85b5PI25TQwI93ZM=";
 }


### PR DESCRIPTION
Update metals to version `1.2.2+57-f1608f84-SNAPSHOT`. See https://scalameta.org/metals/latests.json