### PR TITLE
Update metals to 1.2.2+90-8e975366-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.2.2+80-b278ef9e-SNAPSHOT";
-  "outputHash" = "sha256-BozxceIFo0gLt9jaOkTO5oijHzK1U/x0OPdqIGfYjb8=";
+  "version" = "1.2.2+90-8e975366-SNAPSHOT";
+  "outputHash" = "sha256-70wBDhUbsXwmtAK0IBdy/UNhkBkRkP8N9mQIc7AkMpQ=";
 }


### PR DESCRIPTION
Update metals to version `1.2.2+90-8e975366-SNAPSHOT`. See https://scalameta.org/metals/latests.json