### PR TITLE
Update metals to 1.2.2+102-8e3b9cea-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.2.2+90-8e975366-SNAPSHOT";
-  "outputHash" = "sha256-70wBDhUbsXwmtAK0IBdy/UNhkBkRkP8N9mQIc7AkMpQ=";
+  "version" = "1.2.2+102-8e3b9cea-SNAPSHOT";
+  "outputHash" = "sha256-LbXtHAKCuwLeX62O8YNjDtenD6rO6b3CTqk/xfEqAAE=";
 }


### PR DESCRIPTION
Update metals to version `1.2.2+102-8e3b9cea-SNAPSHOT`. See https://scalameta.org/metals/latests.json