### PR TITLE
Update metals to 1.2.2+117-8cc7a42f-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.2.2+102-8e3b9cea-SNAPSHOT";
-  "outputHash" = "sha256-LbXtHAKCuwLeX62O8YNjDtenD6rO6b3CTqk/xfEqAAE=";
+  "version" = "1.2.2+117-8cc7a42f-SNAPSHOT";
+  "outputHash" = "sha256-8Wh56XvOw6/Y7vXEYgKpBlidMbRA5krOw3iBRyfYG2w=";
 }


### PR DESCRIPTION
Update metals to version `1.2.2+117-8cc7a42f-SNAPSHOT`. See https://scalameta.org/metals/latests.json