### PR TITLE
Update metals to 1.2.2+131-1f16fcc1-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.2.2+117-8cc7a42f-SNAPSHOT";
-  "outputHash" = "sha256-8Wh56XvOw6/Y7vXEYgKpBlidMbRA5krOw3iBRyfYG2w=";
+  "version" = "1.2.2+131-1f16fcc1-SNAPSHOT";
+  "outputHash" = "sha256-Nieek5QKuhvsUJ4FXrRqG84RD448IPGWZuv53PMgr7E=";
 }


### PR DESCRIPTION
Update metals to version `1.2.2+131-1f16fcc1-SNAPSHOT`. See https://scalameta.org/metals/latests.json