### PR TITLE
Update metals to 1.3.0

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.2.2";
-  "outputHash" = "sha256-xk2ionn/lBV8AR7n7OR03UuRCoP1/K6KuohhpRwFock=";
+  "version" = "1.3.0";
+  "outputHash" = "sha256-otN4sqV2a0itLOoJ7x+VSMe0tl3y4WVovbA1HOpZVDw=";
 }


### PR DESCRIPTION
Update metals to version `1.3.0`. See https://scalameta.org/metals/latests.json