### PR TITLE
Update metals to 1.3.0+24-73944e46-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.2.2+131-1f16fcc1-SNAPSHOT";
-  "outputHash" = "sha256-Nieek5QKuhvsUJ4FXrRqG84RD448IPGWZuv53PMgr7E=";
+  "version" = "1.3.0+24-73944e46-SNAPSHOT";
+  "outputHash" = "sha256-nSxftxKdKedtmd3LnCt03B67HW31CjJnl7uV/eTDrfc=";
 }


### PR DESCRIPTION
Update metals to version `1.3.0+24-73944e46-SNAPSHOT`. See https://scalameta.org/metals/latests.json