### PR TITLE
Update metals to 1.3.0+54-85ef0645-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.3.0+42-9d861df1-SNAPSHOT";
-  "outputHash" = "sha256-l+jDeOm/W1m4LFerPC63dpmkWnr7PD1H3FqnPlT+cF0=";
+  "version" = "1.3.0+54-85ef0645-SNAPSHOT";
+  "outputHash" = "sha256-3TR8R5wmW9Xu+qCSoPxC9FNlTLj1Y6nKsK+Njrh1+lc=";
 }


### PR DESCRIPTION
Update metals to version `1.3.0+54-85ef0645-SNAPSHOT`. See https://scalameta.org/metals/latests.json