### PR TITLE
Update metals to 1.3.1

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.3.0";
-  "outputHash" = "sha256-otN4sqV2a0itLOoJ7x+VSMe0tl3y4WVovbA1HOpZVDw=";
+  "version" = "1.3.1";
+  "outputHash" = "sha256-ugTYjXgD5SHagRtc1RNsnfcLAXPeWSHcos82ewr3UIs=";
 }


### PR DESCRIPTION
Update metals to version `1.3.1`. See https://scalameta.org/metals/latests.json