### PR TITLE
Update metals to 1.3.1+5-934bf19f-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.3.0+70-1751bda1-SNAPSHOT";
-  "outputHash" = "sha256-icyqQaVdZFDU8q95Afbdb/+I7Yvt6i1G+Dbw0cxBjTQ=";
+  "version" = "1.3.1+5-934bf19f-SNAPSHOT";
+  "outputHash" = "sha256-9eIrxaSiptBOLA4eF47ddj+FGuFTfhWw/fFGInms2to=";
 }


### PR DESCRIPTION
Update metals to version `1.3.1+5-934bf19f-SNAPSHOT`. See https://scalameta.org/metals/latests.json