### PR TITLE
Update metals to 1.3.1+27-5b582c65-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.3.1+5-934bf19f-SNAPSHOT";
-  "outputHash" = "sha256-9eIrxaSiptBOLA4eF47ddj+FGuFTfhWw/fFGInms2to=";
+  "version" = "1.3.1+27-5b582c65-SNAPSHOT";
+  "outputHash" = "sha256-MI/vlGi8+oF7wcIlIJ4czy/EPATEsEk1hy2fSrJKWyQ=";
 }


### PR DESCRIPTION
Update metals to version `1.3.1+27-5b582c65-SNAPSHOT`. See https://scalameta.org/metals/latests.json