### PR TITLE
Update metals to 1.3.1+49-e292d678-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.3.1+27-5b582c65-SNAPSHOT";
-  "outputHash" = "sha256-MI/vlGi8+oF7wcIlIJ4czy/EPATEsEk1hy2fSrJKWyQ=";
+  "version" = "1.3.1+49-e292d678-SNAPSHOT";
+  "outputHash" = "sha256-htbXEBH9SFnrCLRF5HtI7CdZtn9YEJMX/qMo5G/C+9I=";
 }


### PR DESCRIPTION
Update metals to version `1.3.1+49-e292d678-SNAPSHOT`. See https://scalameta.org/metals/latests.json