### PR TITLE
Update metals to 1.3.1+63-1a8f4659-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.3.1+49-e292d678-SNAPSHOT";
-  "outputHash" = "sha256-htbXEBH9SFnrCLRF5HtI7CdZtn9YEJMX/qMo5G/C+9I=";
+  "version" = "1.3.1+63-1a8f4659-SNAPSHOT";
+  "outputHash" = "sha256-B9CSYtYnWpd2yGg5eypFZ+HXlhaSR4rPABYsTW6/OZ8=";
 }


### PR DESCRIPTION
Update metals to version `1.3.1+63-1a8f4659-SNAPSHOT`. See https://scalameta.org/metals/latests.json