### PR TITLE
Update metals to 1.3.1+75-9f6957da-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.3.1+63-1a8f4659-SNAPSHOT";
-  "outputHash" = "sha256-B9CSYtYnWpd2yGg5eypFZ+HXlhaSR4rPABYsTW6/OZ8=";
+  "version" = "1.3.1+75-9f6957da-SNAPSHOT";
+  "outputHash" = "sha256-keHNlhRTSIn8mRLfp3oRLTvjOxghJ67ZqudJvuO3JbI=";
 }


### PR DESCRIPTION
Update metals to version `1.3.1+75-9f6957da-SNAPSHOT`. See https://scalameta.org/metals/latests.json