### PR TITLE
Update metals to 1.3.2

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.3.1";
-  "outputHash" = "sha256-ugTYjXgD5SHagRtc1RNsnfcLAXPeWSHcos82ewr3UIs=";
+  "version" = "1.3.2";
+  "outputHash" = "sha256-hRESY7TFxUjEkNf0vhCG30mIHZHXoAyZl3nTQ3OvQ0E=";
 }


### PR DESCRIPTION
Update metals to version `1.3.2`. See https://scalameta.org/metals/latests.json