### PR TITLE
Update metals to 1.3.2+5-67992d78-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.3.1+75-9f6957da-SNAPSHOT";
-  "outputHash" = "sha256-keHNlhRTSIn8mRLfp3oRLTvjOxghJ67ZqudJvuO3JbI=";
+  "version" = "1.3.2+5-67992d78-SNAPSHOT";
+  "outputHash" = "sha256-SSw0dibPdHKFG35/5V4gcoIcCcvi1c+BAeyiOyDEF4E=";
 }


### PR DESCRIPTION
Update metals to version `1.3.2+5-67992d78-SNAPSHOT`. See https://scalameta.org/metals/latests.json