### PR TITLE
Update metals to 1.3.3

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.3.2";
-  "outputHash" = "sha256-hRESY7TFxUjEkNf0vhCG30mIHZHXoAyZl3nTQ3OvQ0E=";
+  "version" = "1.3.3";
+  "outputHash" = "sha256-OFpnfAR1BuY0QFCR8Zf210IEMgVDVLQnHNSCM2FbBxk=";
 }


### PR DESCRIPTION
Update metals to version `1.3.3`. See https://scalameta.org/metals/latests.json