### PR TITLE
Update metals to 1.3.3+5-b4a53af7-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.3.2+32-dd8736c9-SNAPSHOT";
-  "outputHash" = "sha256-i961wb+9YmdN8Kjdcv2JZCl5++VT7FFSxgrhTpUqr+U=";
+  "version" = "1.3.3+5-b4a53af7-SNAPSHOT";
+  "outputHash" = "sha256-qJYhLlX1O93Pues+KxwMkt3Vg2K6fc6NB9K2pektl7w=";
 }


### PR DESCRIPTION
Update metals to version `1.3.3+5-b4a53af7-SNAPSHOT`. See https://scalameta.org/metals/latests.json