### PR TITLE
Update metals to 1.3.3+25-49bc7dc2-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.3.3+5-b4a53af7-SNAPSHOT";
-  "outputHash" = "sha256-qJYhLlX1O93Pues+KxwMkt3Vg2K6fc6NB9K2pektl7w=";
+  "version" = "1.3.3+25-49bc7dc2-SNAPSHOT";
+  "outputHash" = "sha256-fVrtGELysZ7IVhU+Q+niDQPsPm542MNqmTRJpkG3qzM=";
 }


### PR DESCRIPTION
Update metals to version `1.3.3+25-49bc7dc2-SNAPSHOT`. See https://scalameta.org/metals/latests.json