### PR TITLE
Update metals to 1.3.4+18-48acd71b-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.3.3+25-49bc7dc2-SNAPSHOT";
-  "outputHash" = "sha256-fVrtGELysZ7IVhU+Q+niDQPsPm542MNqmTRJpkG3qzM=";
+  "version" = "1.3.4+18-48acd71b-SNAPSHOT";
+  "outputHash" = "sha256-qHIGt+MnG0XIu2vrMRu0qtGkdUO01GkyQvLKrfoBrUE=";
 }


### PR DESCRIPTION
Update metals to version `1.3.4+18-48acd71b-SNAPSHOT`. See https://scalameta.org/metals/latests.json