### PR TITLE
Update metals to 1.3.5

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.3.4";
-  "outputHash" = "sha256-g3nOqqoNjZ/lURPO3NVXqmlIbFtwRgKCaz7CJXU1Ups=";
+  "version" = "1.3.5";
+  "outputHash" = "sha256-86/zeoOO5kSAwh7uQTV7nGUGQoIux1rlH5eUgvn3kvY=";
 }


### PR DESCRIPTION
Update metals to version `1.3.5`. See https://scalameta.org/metals/latests.json