### PR TITLE
Update metals to 1.3.5+5-6136010f-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.3.4+18-48acd71b-SNAPSHOT";
-  "outputHash" = "sha256-qHIGt+MnG0XIu2vrMRu0qtGkdUO01GkyQvLKrfoBrUE=";
+  "version" = "1.3.5+5-6136010f-SNAPSHOT";
+  "outputHash" = "sha256-ecAV2ruvWvFBOsAVnH39EoP+XPoUfSetwpxDxqmkvZ4=";
 }


### PR DESCRIPTION
Update metals to version `1.3.5+5-6136010f-SNAPSHOT`. See https://scalameta.org/metals/latests.json