### PR TITLE
Update metals to 1.3.5+34-4cb20ab7-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.3.5+5-6136010f-SNAPSHOT";
-  "outputHash" = "sha256-ecAV2ruvWvFBOsAVnH39EoP+XPoUfSetwpxDxqmkvZ4=";
+  "version" = "1.3.5+34-4cb20ab7-SNAPSHOT";
+  "outputHash" = "sha256-QPCk9nhcloaw3KpzvkXveoEzlAlYdRhcaoCJK1YJeo8=";
 }


### PR DESCRIPTION
Update metals to version `1.3.5+34-4cb20ab7-SNAPSHOT`. See https://scalameta.org/metals/latests.json