### PR TITLE
Update metals to 1.3.5+68-5948c4fe-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.3.5+49-7eaf234a-SNAPSHOT";
-  "outputHash" = "sha256-mkhrFKGd22ZNmRaOfhfBUO1M5HSKS3zbiYRa2iFelx4=";
+  "version" = "1.3.5+68-5948c4fe-SNAPSHOT";
+  "outputHash" = "sha256-/C6GL7JXu0ES1Q2jmpSCxgMgDdaQsxInQohjR1gyfd0=";
 }


### PR DESCRIPTION
Update metals to version `1.3.5+68-5948c4fe-SNAPSHOT`. See https://scalameta.org/metals/latests.json