### PR TITLE
Update metals to 1.3.5+84-92e0d5fa-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.3.5+68-5948c4fe-SNAPSHOT";
-  "outputHash" = "sha256-/C6GL7JXu0ES1Q2jmpSCxgMgDdaQsxInQohjR1gyfd0=";
+  "version" = "1.3.5+84-92e0d5fa-SNAPSHOT";
+  "outputHash" = "sha256-SNj5ykXjHJ6OTDMz5MDat5aTADuIII6DcAWpZaS7o+w=";
 }


### PR DESCRIPTION
Update metals to version `1.3.5+84-92e0d5fa-SNAPSHOT`. See https://scalameta.org/metals/latests.json