### PR TITLE
Update metals to 1.3.5+100-0d1567e7-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.3.5+84-92e0d5fa-SNAPSHOT";
-  "outputHash" = "sha256-SNj5ykXjHJ6OTDMz5MDat5aTADuIII6DcAWpZaS7o+w=";
+  "version" = "1.3.5+100-0d1567e7-SNAPSHOT";
+  "outputHash" = "sha256-n+wimx9oSWZjPGcfd/22Zuo3rhqrNgWrBY+fpXRr8iY=";
 }


### PR DESCRIPTION
Update metals to version `1.3.5+100-0d1567e7-SNAPSHOT`. See https://scalameta.org/metals/latests.json