### PR TITLE
Update metals to 1.3.5+114-8e729b2b-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.3.5+100-0d1567e7-SNAPSHOT";
-  "outputHash" = "sha256-n+wimx9oSWZjPGcfd/22Zuo3rhqrNgWrBY+fpXRr8iY=";
+  "version" = "1.3.5+114-8e729b2b-SNAPSHOT";
+  "outputHash" = "sha256-vt3IDZiodL8vDtVD5LzI5xrneGk0eVUDoEWbBUjroY4=";
 }


### PR DESCRIPTION
Update metals to version `1.3.5+114-8e729b2b-SNAPSHOT`. See https://scalameta.org/metals/latests.json