### PR TITLE
Update metals to 1.3.5+132-8007c4e6-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.3.5+114-8e729b2b-SNAPSHOT";
-  "outputHash" = "sha256-vt3IDZiodL8vDtVD5LzI5xrneGk0eVUDoEWbBUjroY4=";
+  "version" = "1.3.5+132-8007c4e6-SNAPSHOT";
+  "outputHash" = "sha256-mLrpxwJ+y9y7ziUwW6qZH2STwKa6ys29BqSInQTD8BQ=";
 }


### PR DESCRIPTION
Update metals to version `1.3.5+132-8007c4e6-SNAPSHOT`. See https://scalameta.org/metals/latests.json