### PR TITLE
Update metals to 1.3.5+142-fe3dc071-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.3.5+132-8007c4e6-SNAPSHOT";
-  "outputHash" = "sha256-mLrpxwJ+y9y7ziUwW6qZH2STwKa6ys29BqSInQTD8BQ=";
+  "version" = "1.3.5+142-fe3dc071-SNAPSHOT";
+  "outputHash" = "sha256-F4jVBVAfnjDgwZmQF3lCVfLGT9cTQhqJG/ouTAUKh/8=";
 }


### PR DESCRIPTION
Update metals to version `1.3.5+142-fe3dc071-SNAPSHOT`. See https://scalameta.org/metals/latests.json