### PR TITLE
Update metals to 1.3.5+144-f362c1c2-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.3.5+142-fe3dc071-SNAPSHOT";
-  "outputHash" = "sha256-F4jVBVAfnjDgwZmQF3lCVfLGT9cTQhqJG/ouTAUKh/8=";
+  "version" = "1.3.5+144-f362c1c2-SNAPSHOT";
+  "outputHash" = "sha256-dWfEV6y63Fp2tag/tX2QYXhygi3WyB2OPrQ7DfEStHw=";
 }


### PR DESCRIPTION
Update metals to version `1.3.5+144-f362c1c2-SNAPSHOT`. See https://scalameta.org/metals/latests.json