### PR TITLE
Update metals to 1.3.5+165-8a72fa57-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.3.5+144-f362c1c2-SNAPSHOT";
-  "outputHash" = "sha256-dWfEV6y63Fp2tag/tX2QYXhygi3WyB2OPrQ7DfEStHw=";
+  "version" = "1.3.5+165-8a72fa57-SNAPSHOT";
+  "outputHash" = "sha256-nfByoe/V2rXm89bW2xOt8jAY8i4tvFNcRP/UACG3ncg=";
 }


### PR DESCRIPTION
Update metals to version `1.3.5+165-8a72fa57-SNAPSHOT`. See https://scalameta.org/metals/latests.json