### PR TITLE
Update metals to 1.3.5+181-e54b6b20-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.3.5+165-8a72fa57-SNAPSHOT";
-  "outputHash" = "sha256-nfByoe/V2rXm89bW2xOt8jAY8i4tvFNcRP/UACG3ncg=";
+  "version" = "1.3.5+181-e54b6b20-SNAPSHOT";
+  "outputHash" = "sha256-jNgVMG8AgA3YCaPxH9GHqM28eanIyE54yiWDg5OwULc=";
 }


### PR DESCRIPTION
Update metals to version `1.3.5+181-e54b6b20-SNAPSHOT`. See https://scalameta.org/metals/latests.json