### PR TITLE
Update metals to 1.4.0

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.3.5";
-  "outputHash" = "sha256-86/zeoOO5kSAwh7uQTV7nGUGQoIux1rlH5eUgvn3kvY=";
+  "version" = "1.4.0";
+  "outputHash" = "sha256-mmsCdv3zSwsaA00I5sQVy0V4fl1GytdgjVjs2r6x32Q=";
 }


### PR DESCRIPTION
Update metals to version `1.4.0`. See https://scalameta.org/metals/latests.json