### PR TITLE
Update metals to 1.4.0+6-73dc6db8-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.3.5+181-e54b6b20-SNAPSHOT";
-  "outputHash" = "sha256-jNgVMG8AgA3YCaPxH9GHqM28eanIyE54yiWDg5OwULc=";
+  "version" = "1.4.0+6-73dc6db8-SNAPSHOT";
+  "outputHash" = "sha256-6lMdzJX5iTAhFvqZbwCVDMYrkB2fBGQmaWALsRDiuHI=";
 }


### PR DESCRIPTION
Update metals to version `1.4.0+6-73dc6db8-SNAPSHOT`. See https://scalameta.org/metals/latests.json