### PR TITLE
Update metals to 1.4.0+21-824d9b8e-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.4.0+6-73dc6db8-SNAPSHOT";
-  "outputHash" = "sha256-6lMdzJX5iTAhFvqZbwCVDMYrkB2fBGQmaWALsRDiuHI=";
+  "version" = "1.4.0+21-824d9b8e-SNAPSHOT";
+  "outputHash" = "sha256-fY4CFCMEyTRgeOKOtWY6xpT4Fnd8MK8p8WCvD1BHFwI=";
 }


### PR DESCRIPTION
Update metals to version `1.4.0+21-824d9b8e-SNAPSHOT`. See https://scalameta.org/metals/latests.json