### PR TITLE
Update metals to 1.4.0+32-b6a45d5f-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.4.0+21-824d9b8e-SNAPSHOT";
-  "outputHash" = "sha256-fY4CFCMEyTRgeOKOtWY6xpT4Fnd8MK8p8WCvD1BHFwI=";
+  "version" = "1.4.0+32-b6a45d5f-SNAPSHOT";
+  "outputHash" = "sha256-aLP7SQnVX4+v/0FSR+EZ/GtwuuYzpoPxW13XP+VVd00=";
 }


### PR DESCRIPTION
Update metals to version `1.4.0+32-b6a45d5f-SNAPSHOT`. See https://scalameta.org/metals/latests.json