### PR TITLE
Update metals to 1.4.1

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.4.0";
-  "outputHash" = "sha256-mmsCdv3zSwsaA00I5sQVy0V4fl1GytdgjVjs2r6x32Q=";
+  "version" = "1.4.1";
+  "outputHash" = "sha256-CVAPjeTYuv0w57EK/IldJcGz8mTQnyCGAjaUf6La2rU=";
 }


### PR DESCRIPTION
Update metals to version `1.4.1`. See https://scalameta.org/metals/latests.json