### PR TITLE
Update metals to 1.4.1+11-162f30c6-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.4.0+32-b6a45d5f-SNAPSHOT";
-  "outputHash" = "sha256-aLP7SQnVX4+v/0FSR+EZ/GtwuuYzpoPxW13XP+VVd00=";
+  "version" = "1.4.1+11-162f30c6-SNAPSHOT";
+  "outputHash" = "sha256-bSOx6MTiXipKo/G8PxZmljHspj7ZOEGOt8djwtqk7WA=";
 }


### PR DESCRIPTION
Update metals to version `1.4.1+11-162f30c6-SNAPSHOT`. See https://scalameta.org/metals/latests.json