### PR TITLE
Update metals to 1.4.1+45-01974d7c-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.4.1+11-162f30c6-SNAPSHOT";
-  "outputHash" = "sha256-bSOx6MTiXipKo/G8PxZmljHspj7ZOEGOt8djwtqk7WA=";
+  "version" = "1.4.1+45-01974d7c-SNAPSHOT";
+  "outputHash" = "sha256-DLsTFDaaMMjwZ3G2VJfpKUKqxatt4bQ8LTqxQXuhG80=";
 }


### PR DESCRIPTION
Update metals to version `1.4.1+45-01974d7c-SNAPSHOT`. See https://scalameta.org/metals/latests.json