### PR TITLE
Update metals to 1.4.1+62-32814dae-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.4.1+45-01974d7c-SNAPSHOT";
-  "outputHash" = "sha256-DLsTFDaaMMjwZ3G2VJfpKUKqxatt4bQ8LTqxQXuhG80=";
+  "version" = "1.4.1+62-32814dae-SNAPSHOT";
+  "outputHash" = "sha256-PSOoN3BIGYeonc2IMQE5cdfCEQ/C+v2c+EEYUhyKndk=";
 }


### PR DESCRIPTION
Update metals to version `1.4.1+62-32814dae-SNAPSHOT`. See https://scalameta.org/metals/latests.json