### PR TITLE
Update metals to 1.4.1+84-55ba0176-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.4.1+62-32814dae-SNAPSHOT";
-  "outputHash" = "sha256-PSOoN3BIGYeonc2IMQE5cdfCEQ/C+v2c+EEYUhyKndk=";
+  "version" = "1.4.1+84-55ba0176-SNAPSHOT";
+  "outputHash" = "sha256-PmI4fXmpsN7WCZAzNQwX06HKDJTtdwuJ3whpmA3h1aM=";
 }


### PR DESCRIPTION
Update metals to version `1.4.1+84-55ba0176-SNAPSHOT`. See https://scalameta.org/metals/latests.json