### PR TITLE
Update metals to 1.4.1+97-afde2d2e-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.4.1+84-55ba0176-SNAPSHOT";
-  "outputHash" = "sha256-PmI4fXmpsN7WCZAzNQwX06HKDJTtdwuJ3whpmA3h1aM=";
+  "version" = "1.4.1+97-afde2d2e-SNAPSHOT";
+  "outputHash" = "sha256-Jvf6DnaLTKe8JlYnyBp0vJTorlPJnn0g6vdEG0jkzSo=";
 }


### PR DESCRIPTION
Update metals to version `1.4.1+97-afde2d2e-SNAPSHOT`. See https://scalameta.org/metals/latests.json