### PR TITLE
Update metals to 1.4.2

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.4.1";
-  "outputHash" = "sha256-CVAPjeTYuv0w57EK/IldJcGz8mTQnyCGAjaUf6La2rU=";
+  "version" = "1.4.2";
+  "outputHash" = "sha256-AyrjfW4p/dltXu1xOkfVjxtKLB6fPAoxqapBu+z23U4=";
 }


### PR DESCRIPTION
Update metals to version `1.4.2`. See https://scalameta.org/metals/latests.json