### PR TITLE
Update metals to 1.4.2+29-82907609-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.4.1+97-afde2d2e-SNAPSHOT";
-  "outputHash" = "sha256-Jvf6DnaLTKe8JlYnyBp0vJTorlPJnn0g6vdEG0jkzSo=";
+  "version" = "1.4.2+29-82907609-SNAPSHOT";
+  "outputHash" = "sha256-yK1SDxqEyFOh0gxqm/88Rp2vX0huJyd8kA8HC4VMV34=";
 }


### PR DESCRIPTION
Update metals to version `1.4.2+29-82907609-SNAPSHOT`. See https://scalameta.org/metals/latests.json