### PR TITLE
Update metals to 1.4.2+56-70eb6238-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.4.2+41-521cc9df-SNAPSHOT";
-  "outputHash" = "sha256-2/RiYylC6IqnYYInSo45bmZfBJjZ84atKxYpkXpTXDk=";
+  "version" = "1.4.2+56-70eb6238-SNAPSHOT";
+  "outputHash" = "sha256-fxY/Ta41WXvxNgXNS7QMOSMhYxZZploRD0ZHDASJqFw=";
 }


### PR DESCRIPTION
Update metals to version `1.4.2+56-70eb6238-SNAPSHOT`. See https://scalameta.org/metals/latests.json