### PR TITLE
Update metals to 1.4.2+74-17bd4208-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.4.2+56-70eb6238-SNAPSHOT";
-  "outputHash" = "sha256-fxY/Ta41WXvxNgXNS7QMOSMhYxZZploRD0ZHDASJqFw=";
+  "version" = "1.4.2+74-17bd4208-SNAPSHOT";
+  "outputHash" = "sha256-2FQ8dEHwgDPYrd222uYSOBrVUZCisvkHo6jDeVjm4Hs=";
 }


### PR DESCRIPTION
Update metals to version `1.4.2+74-17bd4208-SNAPSHOT`. See https://scalameta.org/metals/latests.json