### PR TITLE
Update metals to 1.5.1+2-a3b9f730-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.4.2+74-17bd4208-SNAPSHOT";
-  "outputHash" = "sha256-2FQ8dEHwgDPYrd222uYSOBrVUZCisvkHo6jDeVjm4Hs=";
+  "version" = "1.5.1+2-a3b9f730-SNAPSHOT";
+  "outputHash" = "sha256-dVpl3fKJ9lRng0kAGBYLsha6VMsyQvW0OtAPVSMUpAQ=";
 }


### PR DESCRIPTION
Update metals to version `1.5.1+2-a3b9f730-SNAPSHOT`. See https://scalameta.org/metals/latests.json