### PR TITLE
Update metals to 1.5.1+15-a8f603c4-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.5.1+2-a3b9f730-SNAPSHOT";
-  "outputHash" = "sha256-dVpl3fKJ9lRng0kAGBYLsha6VMsyQvW0OtAPVSMUpAQ=";
+  "version" = "1.5.1+15-a8f603c4-SNAPSHOT";
+  "outputHash" = "sha256-0et4LiKwf+hullSgtbXNYcLW3tA2w3UjFlJjbHylheE=";
 }


### PR DESCRIPTION
Update metals to version `1.5.1+15-a8f603c4-SNAPSHOT`. See https://scalameta.org/metals/latests.json