### PR TITLE
Update metals to 1.5.1+40-06590c5f-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.5.1+15-a8f603c4-SNAPSHOT";
-  "outputHash" = "sha256-0et4LiKwf+hullSgtbXNYcLW3tA2w3UjFlJjbHylheE=";
+  "version" = "1.5.1+40-06590c5f-SNAPSHOT";
+  "outputHash" = "sha256-7rcSZ2kR/QE2LtU7eHeKtrpfMQ0e0sOwv7tSa6MqzkE=";
 }


### PR DESCRIPTION
Update metals to version `1.5.1+40-06590c5f-SNAPSHOT`. See https://scalameta.org/metals/latests.json