### PR TITLE
Update metals to 1.5.1+56-efcb8322-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.5.1+40-06590c5f-SNAPSHOT";
-  "outputHash" = "sha256-7rcSZ2kR/QE2LtU7eHeKtrpfMQ0e0sOwv7tSa6MqzkE=";
+  "version" = "1.5.1+56-efcb8322-SNAPSHOT";
+  "outputHash" = "sha256-hODJK0YrO2QiDbVJRwwoq0iuiuGgeI4jARMSkFQEGZk=";
 }


### PR DESCRIPTION
Update metals to version `1.5.1+56-efcb8322-SNAPSHOT`. See https://scalameta.org/metals/latests.json