### PR TITLE
Update metals to 1.5.1+70-fab87b08-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.5.1+56-efcb8322-SNAPSHOT";
-  "outputHash" = "sha256-hODJK0YrO2QiDbVJRwwoq0iuiuGgeI4jARMSkFQEGZk=";
+  "version" = "1.5.1+70-fab87b08-SNAPSHOT";
+  "outputHash" = "sha256-I45r8kVGDBXJkOdpmNzzX9DFAlGl/iVHgd2LE+X3Voo=";
 }


### PR DESCRIPTION
Update metals to version `1.5.1+70-fab87b08-SNAPSHOT`. See https://scalameta.org/metals/latests.json