### PR TITLE
Update metals to 1.5.1+87-5b1a7c25-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.5.1+70-fab87b08-SNAPSHOT";
-  "outputHash" = "sha256-I45r8kVGDBXJkOdpmNzzX9DFAlGl/iVHgd2LE+X3Voo=";
+  "version" = "1.5.1+87-5b1a7c25-SNAPSHOT";
+  "outputHash" = "sha256-2nZGTBbTsmXnL/6N9cpcsXlMFUaiFuYPxvHxSW6XIc0=";
 }


### PR DESCRIPTION
Update metals to version `1.5.1+87-5b1a7c25-SNAPSHOT`. See https://scalameta.org/metals/latests.json