### PR TITLE
Update metals to 1.5.1+102-66321e4b-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.5.1+87-5b1a7c25-SNAPSHOT";
-  "outputHash" = "sha256-2nZGTBbTsmXnL/6N9cpcsXlMFUaiFuYPxvHxSW6XIc0=";
+  "version" = "1.5.1+102-66321e4b-SNAPSHOT";
+  "outputHash" = "sha256-efk0uHD6FA1OhEOKSuIGM+K3Ot0omKEwD6gqlIdRUGE=";
 }


### PR DESCRIPTION
Update metals to version `1.5.1+102-66321e4b-SNAPSHOT`. See https://scalameta.org/metals/latests.json