### PR TITLE
Update metals to 1.5.1+121-d5560246-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.5.1+102-66321e4b-SNAPSHOT";
-  "outputHash" = "sha256-efk0uHD6FA1OhEOKSuIGM+K3Ot0omKEwD6gqlIdRUGE=";
+  "version" = "1.5.1+121-d5560246-SNAPSHOT";
+  "outputHash" = "sha256-dyanlMoIdWk2mvlkdZLoh3C0+E8DCOOKEp6bJ5DPls0=";
 }


### PR DESCRIPTION
Update metals to version `1.5.1+121-d5560246-SNAPSHOT`. See https://scalameta.org/metals/latests.json