### PR TITLE
Update metals to 1.5.1+136-3d3982bd-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.5.1+121-d5560246-SNAPSHOT";
-  "outputHash" = "sha256-dyanlMoIdWk2mvlkdZLoh3C0+E8DCOOKEp6bJ5DPls0=";
+  "version" = "1.5.1+136-3d3982bd-SNAPSHOT";
+  "outputHash" = "sha256-9Hh8qoLZV6VlRq13VQLQLQDvJIj3mFyqH09h0UjvXec=";
 }


### PR DESCRIPTION
Update metals to version `1.5.1+136-3d3982bd-SNAPSHOT`. See https://scalameta.org/metals/latests.json