### PR TITLE
Update metals to 1.5.2+25-3c71e7ea-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.5.2+2-29f2d805-SNAPSHOT";
-  "outputHash" = "sha256-0gzoH/+5vzlrqhPcjsQVuDbjWvUDniDT4SgbzpuqMiI=";
+  "version" = "1.5.2+25-3c71e7ea-SNAPSHOT";
+  "outputHash" = "sha256-nt8SxwmyuX3YOo1PlcfRmRUUS93yXQNnp+B0gU/w9qY=";
 }


### PR DESCRIPTION
Update metals to version `1.5.2+25-3c71e7ea-SNAPSHOT`. See https://scalameta.org/metals/latests.json