### PR TITLE
Update metals to 1.5.2+40-28dd5d77-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.5.2+25-3c71e7ea-SNAPSHOT";
-  "outputHash" = "sha256-nt8SxwmyuX3YOo1PlcfRmRUUS93yXQNnp+B0gU/w9qY=";
+  "version" = "1.5.2+40-28dd5d77-SNAPSHOT";
+  "outputHash" = "sha256-sqBEJWRSEo2KxIqX96EUPMztKwXQ3CmXvy+C+FS0RIE=";
 }


### PR DESCRIPTION
Update metals to version `1.5.2+40-28dd5d77-SNAPSHOT`. See https://scalameta.org/metals/latests.json