### PR TITLE
Update metals to 1.5.2+96-a9f5a5ee-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.5.2+80-2d9d29a7-SNAPSHOT";
-  "outputHash" = "sha256-+5vuQb97yN7VPoulJ9aUyNlaN3uGWbuQXHxHpv4gx7M=";
+  "version" = "1.5.2+96-a9f5a5ee-SNAPSHOT";
+  "outputHash" = "sha256-dt2AezD6Jc7Aqzw+STHWWijwKd2SlVYPSKgM1S1kKMY=";
 }


### PR DESCRIPTION
Update metals to version `1.5.2+96-a9f5a5ee-SNAPSHOT`. See https://scalameta.org/metals/latests.json