### PR TITLE
Update metals to 1.5.2+122-7d0064af-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.5.2+96-a9f5a5ee-SNAPSHOT";
-  "outputHash" = "sha256-dt2AezD6Jc7Aqzw+STHWWijwKd2SlVYPSKgM1S1kKMY=";
+  "version" = "1.5.2+122-7d0064af-SNAPSHOT";
+  "outputHash" = "sha256-sssbJ7pB3QixlLZqCsuQddJgnEtTf53+MVKhALXC5M4=";
 }


### PR DESCRIPTION
Update metals to version `1.5.2+122-7d0064af-SNAPSHOT`. See https://scalameta.org/metals/latests.json