### PR TITLE
Update metals to 1.5.3

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.5.2";
-  "outputHash" = "sha256-2pDZ6jSp8RLGyXmsxaMrtJYMaf8dF5YrG2RZk78Zxzo=";
+  "version" = "1.5.3";
+  "outputHash" = "sha256-eJtGqkvSHmqsJCfzioCXYi+5JK0A6frpaswaPyohXxw=";
 }


### PR DESCRIPTION
Update metals to version `1.5.3`. See https://scalameta.org/metals/latests.json