### PR TITLE
Update metals to 1.5.3+17-96f26397-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.5.2+122-7d0064af-SNAPSHOT";
-  "outputHash" = "sha256-sssbJ7pB3QixlLZqCsuQddJgnEtTf53+MVKhALXC5M4=";
+  "version" = "1.5.3+17-96f26397-SNAPSHOT";
+  "outputHash" = "sha256-g0nt1tLkRI2qyhpSGoJEm4GMSKD5p4jEXj4so0nP4xU=";
 }


### PR DESCRIPTION
Update metals to version `1.5.3+17-96f26397-SNAPSHOT`. See https://scalameta.org/metals/latests.json