### PR TITLE
Update metals to 1.5.3+24-f4f4439e-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.5.3+17-96f26397-SNAPSHOT";
-  "outputHash" = "sha256-g0nt1tLkRI2qyhpSGoJEm4GMSKD5p4jEXj4so0nP4xU=";
+  "version" = "1.5.3+24-f4f4439e-SNAPSHOT";
+  "outputHash" = "sha256-tY5FKWS5nrgqRofS5NgIEO4cgn5TXvDiw/nHk6qdBVM=";
 }


### PR DESCRIPTION
Update metals to version `1.5.3+24-f4f4439e-SNAPSHOT`. See https://scalameta.org/metals/latests.json