### PR TITLE
Update metals to 1.5.3+32-6379c279-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.5.3+24-f4f4439e-SNAPSHOT";
-  "outputHash" = "sha256-tY5FKWS5nrgqRofS5NgIEO4cgn5TXvDiw/nHk6qdBVM=";
+  "version" = "1.5.3+32-6379c279-SNAPSHOT";
+  "outputHash" = "sha256-BBgannOwSJeF1Lihsu1qMOVaB1CLehoQdGiyK7reSxE=";
 }


### PR DESCRIPTION
Update metals to version `1.5.3+32-6379c279-SNAPSHOT`. See https://scalameta.org/metals/latests.json