### PR TITLE
Update metals to 1.6.0+27-cb36d9ab-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.5.3+32-6379c279-SNAPSHOT";
+  "version" = "1.6.0+27-cb36d9ab-SNAPSHOT";
   "outputHash" = "sha256-BBgannOwSJeF1Lihsu1qMOVaB1CLehoQdGiyK7reSxE=";
 }


### PR DESCRIPTION
Update metals to version `1.6.0+27-cb36d9ab-SNAPSHOT`. See https://scalameta.org/metals/latests.json