### PR TITLE
Update metals to 1.6.1

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.6.0";
-  "outputHash" = "sha256-mH2RZjtEH7fcUWxQqQHHGXbKj1FnHBBcQnW6ehEWO1Y=";
+  "version" = "1.6.1";
+  "outputHash" = "sha256-UtY11HxHI4l6Z5Xw7KoRDQM9vKoa5OD18IK+6Rbqhvo=";
 }


### PR DESCRIPTION
Update metals to version `1.6.1`. See https://scalameta.org/metals/latests.json