### PR TITLE
Update metals to 1.6.2

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.6.1";
-  "outputHash" = "sha256-UtY11HxHI4l6Z5Xw7KoRDQM9vKoa5OD18IK+6Rbqhvo=";
+  "version" = "1.6.2";
+  "outputHash" = "sha256-NBFI/9qua/hdyxqUnInc6tftmEgay/ALVdlkzgW0b+0=";
 }


### PR DESCRIPTION
Update metals to version `1.6.2`. See https://scalameta.org/metals/latests.json