### PR TITLE
Update metals to 1.6.2+80-b6bc5287-SNAPSHOT

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.5.3+32-6379c279-SNAPSHOT";
+  "version" = "1.6.2+80-b6bc5287-SNAPSHOT";
   "outputHash" = "sha256-BBgannOwSJeF1Lihsu1qMOVaB1CLehoQdGiyK7reSxE=";
 }


### PR DESCRIPTION
Update metals to version `1.6.2+80-b6bc5287-SNAPSHOT`. See https://scalameta.org/metals/latests.json