### PR TITLE
Update metals to 1.6.6

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.6.5";
-  "outputHash" = "sha256-1wvmPBv79KdHIFiUVoGCsrHEH53x+3gtzutjXWLym0E=";
+  "version" = "1.6.6";
+  "outputHash" = "sha256-bFeojnxE5i27K5t9CmeXc5BPJbjpDmdsgDDze0TgsSg=";
 }


### PR DESCRIPTION
Update metals to version `1.6.6`. See https://scalameta.org/metals/latests.json