### PR TITLE
Update metals to 1.6.7

### DIFF
--- a/metals-lock.nix
+++ b/metals-lock.nix
@@ -1,4 +1,4 @@
 {
-  "version" = "1.6.6";
-  "outputHash" = "sha256-bFeojnxE5i27K5t9CmeXc5BPJbjpDmdsgDDze0TgsSg=";
+  "version" = "1.6.7";
+  "outputHash" = "sha256-KrSe4eFzaA5dxPJFwdlpjwjqYKoQf7loyING4DUf8OQ=";
 }


### PR DESCRIPTION
Update metals to version `1.6.7`. See https://scalameta.org/metals/latests.json